### PR TITLE
Add Rules For Clang-Format [BUILD-305]

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,2 @@
+build:clang-format-check --aspects //bazel/clang_format:clang_format_check.bzl%clang_format_check_aspect
+build:clang-format-check --output_groups=report

--- a/clang_format/BUILD
+++ b/clang_format/BUILD
@@ -1,0 +1,27 @@
+load(":choose_clang_format.bzl", "choose_clang_format")
+
+choose_clang_format(
+    name = "clang_format_bin",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "_clang_format_bin",
+    srcs = [":clang_format_bin"],
+)
+
+sh_binary(
+    name = "clang_format",
+    srcs = [
+        "run_clang_format.sh",
+    ],
+    args = [
+        "format_all",
+        "$(location :_clang_format_bin)",
+    ],
+    data = [
+        ":_clang_format_bin",
+        "//:clang_format_config",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/clang_format/choose_clang_format.bzl
+++ b/clang_format/choose_clang_format.bzl
@@ -11,8 +11,10 @@ def _choose_clang_format(ctx):
         then
             echo clang-format \\"\\$@\\" > {0}
         else
-            echo "clang-format-14 / clang-format: command not found"
-            exit 1
+            err_msg='clang-format-14 / clang-format: command not found'
+            echo $err_msg
+            echo "echo "$err_msg">&2" >> {0}
+            echo "exit 1" >> {0}
         fi
         """.format(out.path),
     )

--- a/clang_format/choose_clang_format.bzl
+++ b/clang_format/choose_clang_format.bzl
@@ -7,8 +7,12 @@ def _choose_clang_format(ctx):
         if command -v clang-format-14 &> /dev/null
         then
             echo clang-format-14 \\"\\$@\\" > {0}
-        else
+        elif command -v clang-format &> /dev/null
+        then
             echo clang-format \\"\\$@\\" > {0}
+        else
+            echo "clang-format-14 / clang-format: command not found"
+            exit 1
         fi
         """.format(out.path),
     )

--- a/clang_format/choose_clang_format.bzl
+++ b/clang_format/choose_clang_format.bzl
@@ -1,0 +1,20 @@
+def _choose_clang_format(ctx):
+    out = ctx.actions.declare_file("clang_format_bin.sh")
+
+    ctx.actions.run_shell(
+        outputs = [out],
+        command = """
+        if command -v clang-format-14 &> /dev/null
+        then
+            echo clang-format-14 \\"\\$@\\" > {0}
+        else
+            echo clang-format \\"\\$@\\" > {0}
+        fi
+        """.format(out.path),
+    )
+
+    return [DefaultInfo(files = depset([out]))]
+
+choose_clang_format = rule(
+    implementation = _choose_clang_format,
+)

--- a/clang_format/clang_format_check.bzl
+++ b/clang_format/clang_format_check.bzl
@@ -1,5 +1,3 @@
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
-
 def _check_format(ctx, exe, config, infile, clang_format_bin):
     output = ctx.actions.declare_file(infile.path + ".clang-format.txt")
 

--- a/clang_format/clang_format_check.bzl
+++ b/clang_format/clang_format_check.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 
 def _check_format(ctx, exe, config, infile, clang_format_bin):
-    output = ctx.actions.declare_file(infile.basename + ".clang-format.txt")
+    output = ctx.actions.declare_file(infile.path + ".clang-format.txt")
 
     args = ctx.actions.args()
 

--- a/clang_format/clang_format_check.bzl
+++ b/clang_format/clang_format_check.bzl
@@ -1,0 +1,63 @@
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+
+def _check_format(ctx, exe, config, infile, clang_format_bin):
+    output = ctx.actions.declare_file(infile.basename + ".clang-format.txt")
+
+    args = ctx.actions.args()
+
+    args.add("check_file")
+    args.add(clang_format_bin.path)
+    args.add(infile.path)
+    args.add(output.path)
+
+    ctx.actions.run(
+        inputs = [clang_format_bin, infile, config],
+        outputs = [output],
+        executable = exe,
+        arguments = [args],
+        mnemonic = "ClangFormat",
+        progress_message = "Check clang-format on {}".format(infile.short_path),
+    )
+    return output
+
+def _extract_files(ctx):
+    files = []
+    if hasattr(ctx.rule.attr, "srcs"):
+        for src in ctx.rule.attr.srcs:
+            files += [src for src in src.files.to_list() if src.is_source]
+
+    if hasattr(ctx.rule.attr, "hdrs"):
+        for hdr in ctx.rule.attr.hdrs:
+            files += [hdr for hdr in hdr.files.to_list() if hdr.is_source]
+
+    return files
+
+def _clang_format_check_aspect_impl(target, ctx):
+    # if not a C/C++ target, we are not interested
+    if not CcInfo in target:
+        return []
+
+    exe = ctx.attr._clang_format.files_to_run
+    config = ctx.attr._clang_format_config.files.to_list()[0]
+    clang_format_bin = ctx.attr._clang_format_bin.files.to_list()[0]
+    files = _extract_files(ctx)
+
+    outputs = []
+    for file in files:
+        if file.basename.endswith((".c", ".h", ".cpp", ".cc", ".hpp")):
+            outputs.append(_check_format(ctx, exe, config, file, clang_format_bin))
+
+    return [
+        OutputGroupInfo(report = depset(direct = outputs)),
+    ]
+
+clang_format_check_aspect = aspect(
+    implementation = _clang_format_check_aspect_impl,
+    fragments = ["cpp"],
+    attrs = {
+        "_clang_format": attr.label(default = Label("//bazel/clang_format:clang_format")),
+        "_clang_format_config": attr.label(default = Label("//:clang_format_config")),
+        "_clang_format_bin": attr.label(default = Label("//bazel/clang_format:clang_format_bin")),
+    },
+    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+)

--- a/clang_format/clang_format_check.bzl
+++ b/clang_format/clang_format_check.bzl
@@ -59,5 +59,4 @@ clang_format_check_aspect = aspect(
         "_clang_format_config": attr.label(default = Label("//:clang_format_config")),
         "_clang_format_bin": attr.label(default = Label("//bazel/clang_format:clang_format_bin")),
     },
-    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
 )

--- a/clang_format/run_clang_format.sh
+++ b/clang_format/run_clang_format.sh
@@ -1,0 +1,27 @@
+#! /bin/bash
+# Usages:
+# run_clang_format format_all <CLANG_FORMAT_BIN>
+# run_clang_format check_file <CLANG_FORMAT_BIN> <INPUT> <OUTPUT>
+set -ue
+
+format_all() {
+    cd $BUILD_WORKSPACE_DIRECTORY
+    git ls-files '*.[ch]' '*.cpp' '*.cc' '*.hpp' | xargs $CLANG_FORMAT_BIN -i
+}
+
+check_file() {
+    INPUT=$1
+    OUTPUT=$2
+
+    $CLANG_FORMAT_BIN $INPUT --dry-run -Werror > $OUTPUT
+}
+
+ARG=$1
+CLANG_FORMAT_BIN=$(realpath $2)
+shift 2
+
+if [ "$ARG" == "format_all" ]; then
+    format_all
+elif [ "$ARG" == "check_file" ]; then
+    check_file "$@"
+fi


### PR DESCRIPTION
This PR adds rules for clang-format.

`clang-format-check` is implemented using the actions API - we can use cache functionality.
In order to check formatting in a repo use: `bazel build //... --config clang-format-check`
In order to format a repo use: `bazel run //bazel/clang_format`

explanation:
`clang-format-check` is defined in the `.bazelrc` file. Bazel passes all targets (`//...`) to the `clang_format/clang_format_check.bzl:clang_format_check_aspect` aspect. Bazel then iterates over files in the target and runs `clang-format` on it.
The clang format version is searched in the `clang_format/choose_clang_format.bzl` file. The clang format version is searched only once, and then we use it from the cache.

In order to set up these rules in a project we have to:
- import `.bazelrc`: https://github.com/swift-nav/gnss-converters-bazel/pull/3/files#diff-544556920c45b42cbfe40159b082ce8af6bd929e492d076769226265f215832f
- define `clang_format_config` target with `.clang-format` file: https://github.com/swift-nav/gnss-converters-bazel/pull/3/files#diff-7fc57714ef13c3325ce2a1130202edced92fcccc0c6db34a72f7b57f60d552a3

PR tested here: https://github.com/swift-nav/gnss-converters-bazel/pull/3