### PR TITLE
Initial swift_cc* wrappers

### DIFF
--- a/swift_cc_defs.bzl
+++ b/swift_cc_defs.bzl
@@ -1,24 +1,24 @@
 def swift_cc_library(**kwargs):
-  """Wraps cc_library to enforce standards for a production library.
-  """
+    """Wraps cc_library to enforce standards for a production library.
+    """
     native.cc_library(**kwargs)
 
 def swift_cc_tool_library(**kwargs):
-  """Wraps cc_library to enforce standards for a non-production library.
-  """
+    """Wraps cc_library to enforce standards for a non-production library.
+    """
     native.cc_library(**kwargs)
 
 def swift_cc_binary(**kwargs):
-  """Wraps cc_binary to enforce standards for a production library.
-  """
+    """Wraps cc_binary to enforce standards for a production library.
+    """
     native.cc_binary(**kwargs)
 
 def swift_cc_tool(**kwargs):
-  """Wraps cc_binary to enforce standards for a non-production library.
-  """
+    """Wraps cc_binary to enforce standards for a non-production library.
+    """
     native.cc_binary(**kwargs)
 
 def swift_cc_test(**kwargs):
-  """Wraps cc_test to enforce Swift testing conventions.
-  """
+    """Wraps cc_test to enforce Swift testing conventions.
+    """
     native.cc_test(**kwargs)

--- a/swift_cc_defs.bzl
+++ b/swift_cc_defs.bzl
@@ -1,3 +1,9 @@
+# Name for a unit test
+UNIT = "unit"
+
+# Name for a integration test
+INTEGRATION = "integration"
+
 def swift_cc_library(**kwargs):
     """Wraps cc_library to enforce standards for a production library.
     """
@@ -18,7 +24,20 @@ def swift_cc_tool(**kwargs):
     """
     native.cc_binary(**kwargs)
 
-def swift_cc_test(**kwargs):
+def swift_cc_test(name, type, **kwargs):
     """Wraps cc_test to enforce Swift testing conventions.
+
+    Args:
+        name: A unique name for this rule.
+        type: Specifies whether the test is a unit or integration test.
+
+            These are passed to cc_test as tags which enables running
+            these test types seperately: `bazel test --test_tag_filters=unit //...`
     """
+
+    if not (type == UNIT or type == INTEGRATION):
+        fail("The 'type' attribute must be either UNIT or INTEGRATION")
+
+    kwargs["name"] = name
+    kwargs["tags"] = [type]
     native.cc_test(**kwargs)

--- a/swift_cc_defs.bzl
+++ b/swift_cc_defs.bzl
@@ -24,6 +24,11 @@ def swift_cc_tool(**kwargs):
     """
     native.cc_binary(**kwargs)
 
+def swift_cc_test_library(**kwargs):
+    """Wraps cc_library to enforce Swift test library conventions.
+    """
+    native.cc_library(**kwargs)
+
 def swift_cc_test(name, type, **kwargs):
     """Wraps cc_test to enforce Swift testing conventions.
 

--- a/swift_cc_defs.bzl
+++ b/swift_cc_defs.bzl
@@ -1,0 +1,24 @@
+def swift_cc_library(**kwargs):
+  """Wraps cc_library to enforce standards for a production library.
+  """
+    native.cc_library(**kwargs)
+
+def swift_cc_tool_library(**kwargs):
+  """Wraps cc_library to enforce standards for a non-production library.
+  """
+    native.cc_library(**kwargs)
+
+def swift_cc_binary(**kwargs):
+  """Wraps cc_binary to enforce standards for a production library.
+  """
+    native.cc_binary(**kwargs)
+
+def swift_cc_tool(**kwargs):
+  """Wraps cc_binary to enforce standards for a non-production library.
+  """
+    native.cc_binary(**kwargs)
+
+def swift_cc_test(**kwargs):
+  """Wraps cc_test to enforce Swift testing conventions.
+  """
+    native.cc_test(**kwargs)


### PR DESCRIPTION
Adds equivalents to our `swift_add*` wrappers in cmake.

The only one that's currently implemented is `swift_cc_test`:

The wrapper enforces that tests must be declared either `UNIT` or `INTEGRATION` so that they can be run separately.

In our cmake build this results in different targets: `do-all-unit-tests` and `do-all-integration-tests`.

The bazel way to achieve this is using `tag filters`:
```sh
bazel test --test_tag_filters=unit //...
```

Also note that with bazel we don't need any of the logic required in our cmake build to group the test targets together.

If you want to run all tests defined in the `WORKSPACE` (project): `bazel test //...`.

If you want to run all tests in a "package" (defined by a `BUILD.bazel` file): `bazel test //c/observation_adjuster:all`

If you want a single test target: `bazel test //c:gnss_converters:gnss_converters_test`.

The new wrappers are tested here: https://github.com/swift-nav/gnss-converters-private/pull/1340