### PR TITLE
Add qac compile commands script [BUILD-316]

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,1 @@
-sh_binary(
-    name = "qac_compile_commands",
-    srcs = ["qac_compile_commands.sh"],
-    args = ["$(location //:refresh_compile_commands)"],
-    data = ["//:refresh_compile_commands"],
-)
+exports_files(["qac_compile_commands.sh"])

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,4 @@
+sh_binary(
+    name = "qac_compile_commands",
+    srcs = ["qac_compile_commands.sh"],
+)

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,6 @@
 sh_binary(
     name = "qac_compile_commands",
     srcs = ["qac_compile_commands.sh"],
+    args = ["$(location //:refresh_compile_commands)"],
+    data = ["//:refresh_compile_commands"],
 )

--- a/qac_compile_commands.bzl
+++ b/qac_compile_commands.bzl
@@ -1,0 +1,19 @@
+def qac_compile_commands(name, tool, **kwargs):
+    """Replaces -isystem with -I in a compile_commands.json file.
+
+    This is necessary to get Helix QAC to work correctly.
+
+    Args:
+        name: A unique label for this rule.
+        tool: A label refrencing a @hedron_compile_commands:refresh_compile_commands target.
+
+    """
+    arg = "$(location {})".format(tool)
+    native.sh_binary(
+        name = name,
+        # FIXME: Assumes //bazel is a valid label in the consuming workspace.
+        srcs = ["//bazel:qac_compile_commands.sh"],
+        args = [arg],
+        data = [tool],
+        **kwargs
+    )

--- a/qac_compile_commands.sh
+++ b/qac_compile_commands.sh
@@ -3,7 +3,7 @@
 # This is needed for Helix QAC to work properly.
 # Usage: qac_compile_commands <REFRESH_COMPILE_COMMANDS>
 
-REFRESH_COMPILE_COMMANDS=$(realpath $1)
+REFRESH_COMPILE_COMMANDS=$1
 
 $REFRESH_COMPILE_COMMANDS
 sed -i 's/-isystem/-I/' $BUILD_WORKSPACE_DIRECTORY/compile_commands.json

--- a/qac_compile_commands.sh
+++ b/qac_compile_commands.sh
@@ -1,0 +1,4 @@
+#! /bin/bash
+# This one-line script turns the -isystem flag into the -I flag. This is needed for Helix QAC to work properly.
+
+sed -i 's/-isystem/-I/' $BUILD_WORKSPACE_DIRECTORY/compile_commands.json

--- a/qac_compile_commands.sh
+++ b/qac_compile_commands.sh
@@ -1,4 +1,9 @@
 #! /bin/bash
-# This one-line script turns the -isystem flag into the -I flag. This is needed for Helix QAC to work properly.
+# This script turns the -isystem flag into the -I flag.
+# This is needed for Helix QAC to work properly.
+# Usage: qac_compile_commands <REFRESH_COMPILE_COMMANDS>
 
+REFRESH_COMPILE_COMMANDS=$(realpath $1)
+
+$REFRESH_COMPILE_COMMANDS
 sed -i 's/-isystem/-I/' $BUILD_WORKSPACE_DIRECTORY/compile_commands.json


### PR DESCRIPTION
This script changes the `-I` flag into the `-isystem` flag in `compile_commands.json`. As mentioned [here](https://swift-nav.atlassian.net/wiki/spaces/ENG/pages/2138934679/QAC+Helix+rules+analysis+and+approval?focusedCommentId=2141684606), Helix QAC needs the `-I` flag instead of `-isystem`.
The script can be run with: `bazel run //bazel:qac_compile_commands`
PR tested here: https://github.com/swift-nav/gnss-converters-bazel/pull/4