### PR TITLE
Wrap sh_binary in macro

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,1 @@
-sh_binary(
-    name = "qac_compile_commands",
-    srcs = ["qac_compile_commands.sh"],
-    args = ["$(location //:refresh_compile_commands)"],
-    data = ["//:refresh_compile_commands"],
-)
+exports_files(["qac_compile_commands.sh"])

--- a/qac_compile_commands.bzl
+++ b/qac_compile_commands.bzl
@@ -1,0 +1,18 @@
+def qac_compile_commands(name, tool):
+    """Replaces -isystem with -I in a compile_commands.json file.
+
+    This is necessary to get Helix QAC to work correctly.
+
+    Args:
+        name: A unique label for this rule.
+        tool: A label refrencing a @hedron_compile_commands:refresh_compile_commands target.
+
+    """
+    arg = "$(location {})".format(tool)
+    native.sh_binary(
+        name = name,
+        # FIXME: Assumes //bazel is a valid label in the consuming workspace.
+        srcs = ["//bazel:qac_compile_commands.sh"],
+        args = [arg],
+        data = [tool],
+    )


### PR DESCRIPTION
Wrapping the `sh_binary` target in a macro makes it a little more flexible.

For example we don't have to assume there's a `refresh_compile_commands` target, the caller can just pass in whatever they decided to name it.

The only thing I don't like is we have to reference the `sh` script using its label with respect to the project this macro gets used in. It's only valid if the repo structure is set up a specific way (i.e. a bazel directory at the root of the project).

I tried to use the `Label` wrapper like suggested in the docs: https://bazel.build/extending/macros#label-resolution, but I couldn't get it to work.

I would like to have made this a genrule but the python script in `hedron_compile_commands` depends on an environment variable that is only set when using `bazel run` (can't `bazel run` a genrule).

I tested it here: https://github.com/swift-nav/gnss-converters-bazel/tree/itorres/bazel-qac-2
