### PR TITLE
Add cereal, gzip, nlopt, fast-cpp-csv-parser, eigen and variant [BUILD-364]

### DIFF
--- a/cereal.BUILD
+++ b/cereal.BUILD
@@ -1,0 +1,9 @@
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "cereal",
+    hdrs = glob(["include/**"]),
+    includes = ["include"],
+)

--- a/eigen.BUILD
+++ b/eigen.BUILD
@@ -1,0 +1,25 @@
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+)
+
+cmake(
+    name = "eigen",
+    cache_entries = {
+        "CMAKE_C_FLAGS": "-fPIC",
+    },
+    defines = [
+        "EIGEN_MPL_ONLY",
+        "EIGEN_NO_DEBUG",
+    ],
+    includes = ["eigen3"],
+    lib_source = ":srcs",
+    out_headers_only = True,
+    visibility = ["//visibility:public"],
+)

--- a/eigen.BUILD
+++ b/eigen.BUILD
@@ -1,25 +1,12 @@
-load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
-
 package(
     default_visibility = ["//visibility:public"],
 )
 
-filegroup(
-    name = "srcs",
-    srcs = glob(["**"]),
-)
-
-cmake(
+cc_library(
     name = "eigen",
-    cache_entries = {
-        "CMAKE_C_FLAGS": "-fPIC",
-    },
+    hdrs = glob(["Eigen/**"]),
     defines = [
-        "EIGEN_MPL_ONLY",
         "EIGEN_NO_DEBUG",
     ],
-    includes = ["eigen3"],
-    lib_source = ":srcs",
-    out_headers_only = True,
-    visibility = ["//visibility:public"],
+    includes = ["."],
 )

--- a/fast-cpp-csv-parser.BUILD
+++ b/fast-cpp-csv-parser.BUILD
@@ -1,0 +1,9 @@
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "fast-cpp-csv-parser",
+    hdrs = glob(["**"]),
+    includes = ["."],
+)

--- a/fast_csv.BUILD
+++ b/fast_csv.BUILD
@@ -3,7 +3,7 @@ package(
 )
 
 cc_library(
-    name = "fast-cpp-csv-parser",
+    name = "fast_csv",
     hdrs = glob(["**"]),
     includes = ["."],
 )

--- a/gzip.BUILD
+++ b/gzip.BUILD
@@ -1,0 +1,9 @@
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "gzip",
+    hdrs = glob(["include/**"]),
+    includes = ["include"],
+)

--- a/nlopt.BUILD
+++ b/nlopt.BUILD
@@ -14,7 +14,14 @@ cmake(
     cache_entries = {
         "CMAKE_C_FLAGS": "-fPIC",
     },
-    generate_args = ["-DBUILD_SHARED_LIBS=OFF"],
+    generate_args = [
+        "-DBUILD_SHARED_LIBS=OFF",
+        "-DNLOPT_PYTHON=OFF",
+        "-DNLOPT_OCTAVE=OFF",
+        "-DNLOPT_MATLAB=OFF",
+        "-DNLOPT_GUILE=OFF",
+        "-DNLOPT_SWIG=OFF",
+    ],
     lib_source = ":srcs",
     out_static_libs = ["libnlopt.a"],
     visibility = ["//visibility:public"],

--- a/nlopt.BUILD
+++ b/nlopt.BUILD
@@ -1,0 +1,21 @@
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+)
+
+cmake(
+    name = "nlopt",
+    cache_entries = {
+        "CMAKE_C_FLAGS": "-fPIC",
+    },
+    generate_args = ["-DBUILD_SHARED_LIBS=OFF"],
+    lib_source = ":srcs",
+    out_static_libs = ["libnlopt.a"],
+    visibility = ["//visibility:public"],
+)

--- a/variant.BUILD
+++ b/variant.BUILD
@@ -1,0 +1,9 @@
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "variant",
+    hdrs = glob(["include/**"]),
+    includes = ["include"],
+)


### PR DESCRIPTION
This PR adds support for the following third_party libraries:
- cereal
- gzip
- nlopt
- fast-cpp-csv-parser
- eigen
- variant