### PR TITLE
feature: Build targets with consistent set of compiler flags [BUILD-406]

### DIFF
--- a/swift_cc_defs.bzl
+++ b/swift_cc_defs.bzl
@@ -4,9 +4,10 @@ UNIT = "unit"
 # Name for a integration test
 INTEGRATION = "integration"
 
-def _common_c_opts(pedantic = False):
+def _common_c_opts(nocopts, pedantic = False):
     copts = [
         "-Wall",
+        "-Werror",
         "-Wcast-align",
 #        "-Wunused-but-set-parameter",
 #        "-Wno-free-nonheap-object",
@@ -53,29 +54,20 @@ def _common_c_opts(pedantic = False):
         "-Wno-error=deprecated-declarations",
     ]
 
+    # filter nocopts from the list
+    copts = [copt for copt in copts if copt not in nocopts]
+
     if pedantic:
         copts.append("-pedantic")
 
     return copts
 
-
-def _common_features(**kwargs):
-    return [
-        "treat_warnings_as_errors", # Not available until Bazel 6.0!
-        "c99_standard",
-        "cxx14_standard",
-        "no_rtti",
-        "no_exceptions",
-    ]
-
-
 def swift_cc_library(**kwargs):
     """Wraps cc_library to enforce standards for a production library.
     """
-    features = _common_features()
-    kwargs["features"] = (kwargs["features"] if "features" in kwargs else []) + features
+    nocopts = kwargs.pop("nocopts", [])
 
-    copts = _common_c_opts(pedantic = True)
+    copts = _common_c_opts(nocopts, pedantic = True)
     kwargs["copts"] = (kwargs["copts"] if "copts" in kwargs else []) + copts
 
     native.cc_library(**kwargs)
@@ -84,10 +76,9 @@ def swift_cc_library(**kwargs):
 def swift_cc_tool_library(**kwargs):
     """Wraps cc_library to enforce standards for a non-production library.
     """
-    features = _common_features()
-    kwargs["features"] = (kwargs["features"] if "features" in kwargs else []) + features
+    nocopts = kwargs.pop("nocopts", [])
 
-    copts = _common_c_opts(pedantic = False)
+    copts = _common_c_opts(nocopts, pedantic = False)
     kwargs["copts"] = (kwargs["copts"] if "copts" in kwargs else []) + copts
 
     native.cc_library(**kwargs)
@@ -96,10 +87,9 @@ def swift_cc_tool_library(**kwargs):
 def swift_cc_binary(**kwargs):
     """Wraps cc_binary to enforce standards for a production binary.
     """
-    features = _common_features()
-    kwargs["features"] = (kwargs["features"] if "features" in kwargs else []) + features
+    nocopts = kwargs.pop("nocopts", [])
 
-    copts = _common_c_opts(pedantic = True)
+    copts = _common_c_opts(nocopts, pedantic = True)
     kwargs["copts"] = (kwargs["copts"] if "copts" in kwargs else []) + copts
 
     native.cc_binary(**kwargs)
@@ -108,10 +98,9 @@ def swift_cc_binary(**kwargs):
 def swift_cc_tool(**kwargs):
     """Wraps cc_binary to enforce standards for a non-production binary.
     """
-    features = _common_features()
-    kwargs["features"] = (kwargs["features"] if "features" in kwargs else []) + features
+    nocopts = kwargs.pop("nocopts", [])
 
-    copts = _common_c_opts(pedantic = False)
+    copts = _common_c_opts(nocopts, pedantic = False)
     kwargs["copts"] = (kwargs["copts"] if "copts" in kwargs else []) + copts
 
     native.cc_binary(**kwargs)

--- a/swift_cc_defs.bzl
+++ b/swift_cc_defs.bzl
@@ -7,9 +7,9 @@ INTEGRATION = "integration"
 def _common_c_opts(pedantic = False):
     copts = [
         "-Wall",
-        "-Wunused-but-set-parameter",
-        "-Wno-free-nonheap-object",
         "-Wcast-align",
+#        "-Wunused-but-set-parameter",
+#        "-Wno-free-nonheap-object",
         "-Wcast-qual",
         "-Wchar-subscripts",
         "-Wcomment",
@@ -74,7 +74,6 @@ def swift_cc_library(**kwargs):
     """
     features = _common_features()
     kwargs["features"] = (kwargs["features"] if "features" in kwargs else []) + features
-    print(kwargs["features"])
 
     copts = _common_c_opts(pedantic = True)
     kwargs["copts"] = (kwargs["copts"] if "copts" in kwargs else []) + copts

--- a/swift_cc_defs.bzl
+++ b/swift_cc_defs.bzl
@@ -63,27 +63,26 @@ def _common_c_opts(nocopts, pedantic = False):
     return copts
 
 def swift_cc_library(**kwargs):
-    """Wraps cc_library to enforce a standards for a production library.
+    """Wraps cc_library to enforce standards for a production library.
 
     Primarily this consists of a default set of compiler options and
     language standards.
 
-    Production targets (swift_cc_*), are compiled with the -pedantic flag.
+    Production targets (swift_cc*), are compiled with the -pedantic flag.
 
     Args:
         **kwargs: See https://bazel.build/reference/be/c-cpp#cc_library
-            
+
             An additional attribute nocopts is supported. This
-            attribute takes a list of flags to remove from the 
+            attribute takes a list of flags to remove from the
             default compiler options. Use judiciously.
     """
-    nocopts = kwargs.pop("nocopts", [])
+    nocopts = kwargs.pop("nocopts", [])  # pop because nocopts is a depricated cc* attr.
 
     copts = _common_c_opts(nocopts, pedantic = True)
     kwargs["copts"] = (kwargs["copts"] if "copts" in kwargs else []) + copts
 
     native.cc_library(**kwargs)
-
 
 def swift_cc_tool_library(**kwargs):
     """Wraps cc_library to enforce standards for a non-production library.
@@ -91,14 +90,14 @@ def swift_cc_tool_library(**kwargs):
     Primarily this consists of a default set of compiler options and
     language standards.
 
-    Non-production target (swift_cc_tool*), are compiled without the
+    Non-production targets (swift_cc_tool*), are compiled without the
     -pedantic flag.
 
     Args:
         **kwargs: See https://bazel.build/reference/be/c-cpp#cc_library
-            
+
             An additional attribute nocopts is supported. This
-            attribute takes a list of flags to remove from the 
+            attribute takes a list of flags to remove from the
             default compiler options. Use judiciously.
     """
     nocopts = kwargs.pop("nocopts", [])
@@ -107,7 +106,6 @@ def swift_cc_tool_library(**kwargs):
     kwargs["copts"] = (kwargs["copts"] if "copts" in kwargs else []) + copts
 
     native.cc_library(**kwargs)
-
 
 def swift_cc_binary(**kwargs):
     """Wraps cc_binary to enforce standards for a production binary.
@@ -119,9 +117,9 @@ def swift_cc_binary(**kwargs):
 
     Args:
         **kwargs: See https://bazel.build/reference/be/c-cpp#cc_binary
-            
+
             An additional attribute nocopts is supported. This
-            attribute takes a list of flags to remove from the 
+            attribute takes a list of flags to remove from the
             default compiler options. Use judiciously.
     """
     nocopts = kwargs.pop("nocopts", [])
@@ -131,21 +129,20 @@ def swift_cc_binary(**kwargs):
 
     native.cc_binary(**kwargs)
 
-
 def swift_cc_tool(**kwargs):
     """Wraps cc_binary to enforce standards for a non-production binary.
 
     Primarily this consists of a default set of compiler options and
     language standards.
 
-    Non-production target (swift_cc_tool*), are compiled without the
+    Non-production targets (swift_cc_tool*), are compiled without the
     -pedantic flag.
 
     Args:
         **kwargs: See https://bazel.build/reference/be/c-cpp#cc_binary
-            
+
             An additional attribute nocopts is supported. This
-            attribute takes a list of flags to remove from the 
+            attribute takes a list of flags to remove from the
             default compiler options. Use judiciously.
     """
     nocopts = kwargs.pop("nocopts", [])
@@ -155,7 +152,6 @@ def swift_cc_tool(**kwargs):
 
     native.cc_binary(**kwargs)
 
-
 def swift_cc_test_library(**kwargs):
     """Wraps cc_library to enforce Swift test library conventions.
 
@@ -163,7 +159,6 @@ def swift_cc_test_library(**kwargs):
         **kwargs: See https://bazel.build/reference/be/c-cpp#cc_test
     """
     native.cc_library(**kwargs)
-
 
 def swift_cc_test(name, type, **kwargs):
     """Wraps cc_test to enforce Swift testing conventions.

--- a/swift_cc_defs.bzl
+++ b/swift_cc_defs.bzl
@@ -63,7 +63,19 @@ def _common_c_opts(nocopts, pedantic = False):
     return copts
 
 def swift_cc_library(**kwargs):
-    """Wraps cc_library to enforce standards for a production library.
+    """Wraps cc_library to enforce a standards for a production library.
+
+    Primarily this consists of a default set of compiler options and
+    language standards.
+
+    Production targets (swift_cc_*), are compiled with the -pedantic flag.
+
+    Args:
+        **kwargs: See https://bazel.build/reference/be/c-cpp#cc_library
+            
+            An additional attribute nocopts is supported. This
+            attribute takes a list of flags to remove from the 
+            default compiler options.
     """
     nocopts = kwargs.pop("nocopts", [])
 
@@ -75,6 +87,19 @@ def swift_cc_library(**kwargs):
 
 def swift_cc_tool_library(**kwargs):
     """Wraps cc_library to enforce standards for a non-production library.
+
+    Primarily this consists of a default set of compiler options and
+    language standards.
+
+    Non-production target (swift_cc_tool*), are compiled without the
+    -pedantic flag.
+
+    Args:
+        **kwargs: See https://bazel.build/reference/be/c-cpp#cc_library
+            
+            An additional attribute nocopts is supported. This
+            attribute takes a list of flags to remove from the 
+            default compiler options.
     """
     nocopts = kwargs.pop("nocopts", [])
 
@@ -86,6 +111,18 @@ def swift_cc_tool_library(**kwargs):
 
 def swift_cc_binary(**kwargs):
     """Wraps cc_binary to enforce standards for a production binary.
+
+    Primarily this consists of a default set of compiler options and
+    language standards.
+
+    Production targets (swift_cc*), are compiled with the -pedantic flag.
+
+    Args:
+        **kwargs: See https://bazel.build/reference/be/c-cpp#cc_binary
+            
+            An additional attribute nocopts is supported. This
+            attribute takes a list of flags to remove from the 
+            default compiler options.
     """
     nocopts = kwargs.pop("nocopts", [])
 
@@ -97,6 +134,19 @@ def swift_cc_binary(**kwargs):
 
 def swift_cc_tool(**kwargs):
     """Wraps cc_binary to enforce standards for a non-production binary.
+
+    Primarily this consists of a default set of compiler options and
+    language standards.
+
+    Non-production target (swift_cc_tool*), are compiled without the
+    -pedantic flag.
+
+    Args:
+        **kwargs: See https://bazel.build/reference/be/c-cpp#cc_binary
+            
+            An additional attribute nocopts is supported. This
+            attribute takes a list of flags to remove from the 
+            default compiler options.
     """
     nocopts = kwargs.pop("nocopts", [])
 
@@ -108,6 +158,9 @@ def swift_cc_tool(**kwargs):
 
 def swift_cc_test_library(**kwargs):
     """Wraps cc_library to enforce Swift test library conventions.
+
+    Args:
+        **kwargs: See https://bazel.build/reference/be/c-cpp#cc_test
     """
     native.cc_library(**kwargs)
 
@@ -121,6 +174,8 @@ def swift_cc_test(name, type, **kwargs):
 
             These are passed to cc_test as tags which enables running
             these test types seperately: `bazel test --test_tag_filters=unit //...`
+
+        **kwargs: See https://bazel.build/reference/be/c-cpp#cc_test
     """
 
     if not (type == UNIT or type == INTEGRATION):

--- a/swift_cc_defs.bzl
+++ b/swift_cc_defs.bzl
@@ -4,48 +4,125 @@ UNIT = "unit"
 # Name for a integration test
 INTEGRATION = "integration"
 
+def _common_c_opts(pedantic = False):
+    copts = [
+        "-Wall",
+        "-Wunused-but-set-parameter",
+        "-Wno-free-nonheap-object",
+        "-Wcast-align",
+        "-Wcast-qual",
+        "-Wchar-subscripts",
+        "-Wcomment",
+        "-Wconversion",
+        "-Wdisabled-optimization",
+        "-Wextra",
+        "-Wfloat-equal",
+        "-Wformat",
+        "-Wformat-security",
+        "-Wformat-y2k",
+        "-Wimplicit-fallthrough",
+        "-Wimport",
+        "-Winit-self",
+        "-Winvalid-pch",
+        "-Wmissing-braces",
+        "-Wmissing-field-initializers",
+        #"-Wmissing-include-dirs",
+        "-Wparentheses",
+        "-Wpointer-arith",
+        "-Wredundant-decls",
+        "-Wreturn-type",
+        "-Wsequence-point",
+        "-Wshadow",
+        "-Wsign-compare",
+        "-Wstack-protector",
+        "-Wswitch",
+        "-Wswitch-default",
+        "-Wswitch-enum",
+        "-Wtrigraphs",
+        "-Wuninitialized",
+        "-Wunknown-pragmas",
+        "-Wunreachable-code",
+        "-Wunused",
+        "-Wunused-function",
+        "-Wunused-label",
+        "-Wunused-parameter",
+        "-Wunused-value",
+        "-Wunused-variable",
+        "-Wvolatile-register-var",
+        "-Wwrite-strings",
+        "-Wno-error=deprecated-declarations",
+    ]
+
+    if pedantic:
+        copts.append("-pedantic")
+
+    return copts
+
+
 def _common_features(**kwargs):
     return [
+        "treat_warnings_as_errors", # Not available until Bazel 6.0!
         "c99_standard",
-        "cxx14_standard", 
-        "no_rtti", 
+        "cxx14_standard",
+        "no_rtti",
         "no_exceptions",
-        "warnings",
-        "werror",
     ]
+
 
 def swift_cc_library(**kwargs):
     """Wraps cc_library to enforce standards for a production library.
     """
     features = _common_features()
     kwargs["features"] = (kwargs["features"] if "features" in kwargs else []) + features
+    print(kwargs["features"])
+
+    copts = _common_c_opts(pedantic = True)
+    kwargs["copts"] = (kwargs["copts"] if "copts" in kwargs else []) + copts
+
     native.cc_library(**kwargs)
+
 
 def swift_cc_tool_library(**kwargs):
     """Wraps cc_library to enforce standards for a non-production library.
     """
     features = _common_features()
     kwargs["features"] = (kwargs["features"] if "features" in kwargs else []) + features
+
+    copts = _common_c_opts(pedantic = False)
+    kwargs["copts"] = (kwargs["copts"] if "copts" in kwargs else []) + copts
+
     native.cc_library(**kwargs)
+
 
 def swift_cc_binary(**kwargs):
     """Wraps cc_binary to enforce standards for a production binary.
     """
     features = _common_features()
     kwargs["features"] = (kwargs["features"] if "features" in kwargs else []) + features
+
+    copts = _common_c_opts(pedantic = True)
+    kwargs["copts"] = (kwargs["copts"] if "copts" in kwargs else []) + copts
+
     native.cc_binary(**kwargs)
+
 
 def swift_cc_tool(**kwargs):
     """Wraps cc_binary to enforce standards for a non-production binary.
     """
     features = _common_features()
     kwargs["features"] = (kwargs["features"] if "features" in kwargs else []) + features
+
+    copts = _common_c_opts(pedantic = False)
+    kwargs["copts"] = (kwargs["copts"] if "copts" in kwargs else []) + copts
+
     native.cc_binary(**kwargs)
+
 
 def swift_cc_test_library(**kwargs):
     """Wraps cc_library to enforce Swift test library conventions.
     """
     native.cc_library(**kwargs)
+
 
 def swift_cc_test(name, type, **kwargs):
     """Wraps cc_test to enforce Swift testing conventions.

--- a/swift_cc_defs.bzl
+++ b/swift_cc_defs.bzl
@@ -4,24 +4,42 @@ UNIT = "unit"
 # Name for a integration test
 INTEGRATION = "integration"
 
+def _common_features(**kwargs):
+    return [
+        "c99_standard",
+        "cxx14_standard", 
+        "no_rtti", 
+        "no_exceptions",
+        "warnings",
+        "werror",
+    ]
+
 def swift_cc_library(**kwargs):
     """Wraps cc_library to enforce standards for a production library.
     """
+    features = _common_features()
+    kwargs["features"] = (kwargs["features"] if "features" in kwargs else []) + features
     native.cc_library(**kwargs)
 
 def swift_cc_tool_library(**kwargs):
     """Wraps cc_library to enforce standards for a non-production library.
     """
+    features = _common_features()
+    kwargs["features"] = (kwargs["features"] if "features" in kwargs else []) + features
     native.cc_library(**kwargs)
 
 def swift_cc_binary(**kwargs):
     """Wraps cc_binary to enforce standards for a production binary.
     """
+    features = _common_features()
+    kwargs["features"] = (kwargs["features"] if "features" in kwargs else []) + features
     native.cc_binary(**kwargs)
 
 def swift_cc_tool(**kwargs):
     """Wraps cc_binary to enforce standards for a non-production binary.
     """
+    features = _common_features()
+    kwargs["features"] = (kwargs["features"] if "features" in kwargs else []) + features
     native.cc_binary(**kwargs)
 
 def swift_cc_test_library(**kwargs):

--- a/swift_cc_defs.bzl
+++ b/swift_cc_defs.bzl
@@ -5,12 +5,11 @@ UNIT = "unit"
 INTEGRATION = "integration"
 
 def _common_c_opts(nocopts, pedantic = False):
+    # The following are set by default by Bazel:
+    # -Wall, -Wunused-but-set-parameter, -Wno-free-heap-object
     copts = [
-        "-Wall",
         "-Werror",
         "-Wcast-align",
-#        "-Wunused-but-set-parameter",
-#        "-Wno-free-nonheap-object",
         "-Wcast-qual",
         "-Wchar-subscripts",
         "-Wcomment",
@@ -27,7 +26,6 @@ def _common_c_opts(nocopts, pedantic = False):
         "-Winvalid-pch",
         "-Wmissing-braces",
         "-Wmissing-field-initializers",
-        #"-Wmissing-include-dirs",
         "-Wparentheses",
         "-Wpointer-arith",
         "-Wredundant-decls",
@@ -52,9 +50,11 @@ def _common_c_opts(nocopts, pedantic = False):
         "-Wvolatile-register-var",
         "-Wwrite-strings",
         "-Wno-error=deprecated-declarations",
+        #TODO: [BUILD-405] - Figure out why build breaks with this flag
+        #"-Wmissing-include-dirs"
     ]
 
-    # filter nocopts from the list
+    # filter nocopts from the default list
     copts = [copt for copt in copts if copt not in nocopts]
 
     if pedantic:
@@ -75,7 +75,7 @@ def swift_cc_library(**kwargs):
             
             An additional attribute nocopts is supported. This
             attribute takes a list of flags to remove from the 
-            default compiler options.
+            default compiler options. Use judiciously.
     """
     nocopts = kwargs.pop("nocopts", [])
 
@@ -99,7 +99,7 @@ def swift_cc_tool_library(**kwargs):
             
             An additional attribute nocopts is supported. This
             attribute takes a list of flags to remove from the 
-            default compiler options.
+            default compiler options. Use judiciously.
     """
     nocopts = kwargs.pop("nocopts", [])
 
@@ -122,7 +122,7 @@ def swift_cc_binary(**kwargs):
             
             An additional attribute nocopts is supported. This
             attribute takes a list of flags to remove from the 
-            default compiler options.
+            default compiler options. Use judiciously.
     """
     nocopts = kwargs.pop("nocopts", [])
 
@@ -146,7 +146,7 @@ def swift_cc_tool(**kwargs):
             
             An additional attribute nocopts is supported. This
             attribute takes a list of flags to remove from the 
-            default compiler options.
+            default compiler options. Use judiciously.
     """
     nocopts = kwargs.pop("nocopts", [])
 

--- a/swift_cc_defs.bzl
+++ b/swift_cc_defs.bzl
@@ -77,7 +77,7 @@ def swift_cc_library(**kwargs):
             attribute takes a list of flags to remove from the
             default compiler options. Use judiciously.
     """
-    nocopts = kwargs.pop("nocopts", [])  # pop because nocopts is a depricated cc* attr.
+    nocopts = kwargs.pop("nocopts", [])  # pop because nocopts is a deprecated cc* attr.
 
     copts = _common_c_opts(nocopts, pedantic = True)
     kwargs["copts"] = (kwargs["copts"] if "copts" in kwargs else []) + copts


### PR DESCRIPTION
Initial set of default compiler options for swift targets.

Adds a new attribute to `swift_cc*` wrappers; `nocopts` that enables removing these default flags.

(It's worth mentioning that `nocopts` used to be part of the cc_rules API, but it was deprecated)

This should be equivalent to our CMake build with a couple of notable exceptions:
- Currently no support for setting C/C++ standards
- No C++ specific flags - RTTI & Exceptions
- We have build issues with `-Wmissing-include-dirs`

Bazel doesn't provide a mechanism for distinguishing between C options and C++ options at the `cc_*` rules level, so we ran into issues trying to build targets that mix C and C++ code. For example:
```starlark
cc_library(
    name = "example",
    srcs = [
        "src/foo.cpp", # requires c++14 to build
        "src/bar.c"
    ],
    copts = [
        "-std=c++14",
        "-Werror",
    ]
)
```

Trying to compile the c file with -std=c++14 causes a warning, and -Werror turns that into an error.

We're exploring several different options for working around this, but in the mean time we want to enable the basic set of flags as we add bazel support to more of the codebase.

# Related PRs
- https://github.com/swift-nav/gnss-converters-private/pull/1358